### PR TITLE
Handle some parsing edge cases and add support for disk IO events

### DIFF
--- a/src/LinuxTracing.Tests/EventParseTests.cs
+++ b/src/LinuxTracing.Tests/EventParseTests.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using Xunit;
 using System.Linq.Expressions;
+using System;
 
 namespace LinuxTracingTests
 {
@@ -65,7 +66,7 @@ namespace LinuxTracingTests
                     Assert.Equal(pids[i], linuxEvent.ProcessID);
                     Assert.Equal(tids[i], linuxEvent.ThreadID);
                     Assert.Equal(cpus[i], linuxEvent.CpuNumber);
-                    Assert.Equal(times[i], linuxEvent.TimeMSec);
+                    Assert.True(Math.Abs(times[i] - linuxEvent.TimeMSec) <= 0.0001);
                     Assert.Equal(timeProperties[i], linuxEvent.TimeProperty);
                     Assert.Equal(events[i], linuxEvent.EventName);
                     Assert.Equal(eventProperties[i], linuxEvent.EventProperty);
@@ -255,6 +256,23 @@ namespace LinuxTracingTests
                 events: new string[] { "event_name", "event_name", "event_name", "event_name", "event_name", "event_name" },
                 eventProperties: new string[] { "event_properties", "event_properties", "event_properties", "event_properties", "event_properties", "event_properties" },
                 eventKinds: null,
+                switches: null);
+        }
+
+        [Fact]
+        public void DiskIoNoStacks()
+        {
+            string path = Constants.GetTestingPerfDumpPath("disk_io_no_stacks");
+            HeaderTest(path, blockedTime: false,
+                commands: new string[] { "fio", "swapper", "fio", "swapper" },
+                pids: new int[] { 236193, 0, 236193, 0 },
+                tids: new int[] { 236193, 0, 236193, 0 },
+                cpus: new int[] { 21, 12, 21, 12 },
+                times: new double[] { 1791.544, 1791.615, 1791.628, 1791.699 },
+                timeProperties: new int[] { 1, 1, 1, 1 },
+                events: new string[] { "block", "block", "block", "block" },
+                eventProperties: new string[] { "block_rq_issue: 259,76 R 4096 () 57622160 + 8 [fio] ffffffff8beead90 blk_mq_start_request ([kernel.kallsyms])", "block_rq_complete: 259,76 R () 57622160 + 8 [0] ffffffff8bee2b4c blk_update_request ([kernel.kallsyms])", "block_rq_issue: 259,76 R 4096 () 82612968 + 8 [fio] ffffffff8beead90 blk_mq_start_request ([kernel.kallsyms])", "block_rq_complete: 259,76 R () 82612968 + 8 [0] ffffffff8bee2b4c blk_update_request ([kernel.kallsyms])" },
+                eventKinds: new EventKind[] { EventKind.BlockRequestIssue, EventKind.BlockRequestComplete, EventKind.BlockRequestIssue, EventKind.BlockRequestComplete },
                 switches: null);
         }
     }

--- a/src/LinuxTracing.Tests/Sources/disk_io_no_stacks.perf.data.dump
+++ b/src/LinuxTracing.Tests/Sources/disk_io_no_stacks.perf.data.dump
@@ -1,0 +1,4 @@
+﻿             fio 236193/236193 [021] 1.791544:          1    block:block_rq_issue: 259,76 R 4096 () 57622160 + 8 [fio] ffffffff8beead90 blk_mq_start_request ([kernel.kallsyms])
+         swapper     0/0     [012] 1.791615:          1 block:block_rq_complete: 259,76 R () 57622160 + 8 [0] ffffffff8bee2b4c blk_update_request ([kernel.kallsyms])
+             fio 236193/236193 [021] 1.791628:          1    block:block_rq_issue: 259,76 R 4096 () 82612968 + 8 [fio] ffffffff8beead90 blk_mq_start_request ([kernel.kallsyms])
+         swapper     0/0     [012] 1.791699:          1 block:block_rq_complete: 259,76 R () 82612968 + 8 [0] ffffffff8bee2b4c blk_update_request ([kernel.kallsyms])

--- a/src/LinuxTracing.Tests/Sources/no_stack_frames.perf.data.dump
+++ b/src/LinuxTracing.Tests/Sources/no_stack_frames.perf.data.dump
@@ -1,4 +1,4 @@
-﻿comm  0/0  [000] 0.0: event: event_properties 
+﻿comm  0/0  [000] 0.0: event/call-graph=no/: event_properties 
 
 comm  0/0  [000] 0.0: event: event_properties
 	address symbol (module)


### PR DESCRIPTION
Handle cases where the trace doesn't have stacks - detect stack frames via them starting with a tab instead of ending with 2 newlines.
Handle cases where an event has a custom parameter list (will have 'event_name/param_list/:').
Add support for block:block_rq_issue and block:block_rq_complete events.