### PR TITLE
Add support for sched:sched_wakeup event

### DIFF
--- a/src/LinuxTracing.Tests/EventParseTests.cs
+++ b/src/LinuxTracing.Tests/EventParseTests.cs
@@ -275,5 +275,22 @@ namespace LinuxTracingTests
                 eventKinds: new EventKind[] { EventKind.BlockRequestIssue, EventKind.BlockRequestComplete, EventKind.BlockRequestIssue, EventKind.BlockRequestComplete },
                 switches: null);
         }
+
+        [Fact]
+        public void OneWakeup()
+        {
+            string path = Constants.GetTestingPerfDumpPath("one_wakeup");
+            HeaderTest(path, blockedTime: false,
+                commands: new string[] { "swapper" },
+                pids: new int[] { 0 },
+                tids: new int[] { 0 },
+                cpus: new int[] { 9 },
+                times: new double[] { 0.0 },
+                timeProperties: new int[] { 1 },
+                events: new string[] { "sched" },
+                eventProperties: new string[] { "sched_wakeup: comm=fio pid=243615 prio=120 target_cpu=031 ffffffff8bad311d ttwu_do_wakeup ([kernel.kallsyms])" },
+                eventKinds: new EventKind[] { EventKind.Wakeup },
+                switches: null);
+        }
     }
 }

--- a/src/LinuxTracing.Tests/EventParseTests.cs
+++ b/src/LinuxTracing.Tests/EventParseTests.cs
@@ -281,15 +281,15 @@ namespace LinuxTracingTests
         {
             string path = Constants.GetTestingPerfDumpPath("one_wakeup");
             HeaderTest(path, blockedTime: false,
-                commands: new string[] { "swapper" },
-                pids: new int[] { 0 },
-                tids: new int[] { 0 },
-                cpus: new int[] { 9 },
-                times: new double[] { 0.0 },
-                timeProperties: new int[] { 1 },
-                events: new string[] { "sched" },
-                eventProperties: new string[] { "sched_wakeup: comm=fio pid=243615 prio=120 target_cpu=031 ffffffff8bad311d ttwu_do_wakeup ([kernel.kallsyms])" },
-                eventKinds: new EventKind[] { EventKind.Wakeup },
+                commands: new string[] { "swapper", "swapper" },
+                pids: new int[] { 0, 0 },
+                tids: new int[] { 0, 0 },
+                cpus: new int[] { 9, 9 },
+                times: new double[] { 0.0, 0.0 },
+                timeProperties: new int[] { 1, 1 },
+                events: new string[] { "sched", "sched" },
+                eventProperties: new string[] { "sched_wakeup: comm=fio pid=243615 prio=120 target_cpu=031 ffffffff8bad311d ttwu_do_wakeup ([kernel.kallsyms])", "sched_wakeup: task fio:243615 [120] success=1 [031] ffffffff8bad311d ttwu_do_wakeup ([kernel.kallsyms])" },
+                eventKinds: new EventKind[] { EventKind.Wakeup, EventKind.Wakeup },
                 switches: null);
         }
     }

--- a/src/LinuxTracing.Tests/Sources/one_wakeup.perf.data.dump
+++ b/src/LinuxTracing.Tests/Sources/one_wakeup.perf.data.dump
@@ -1,0 +1,1 @@
+﻿         swapper     0/0     [009] 0.0:          1                sched:sched_wakeup: comm=fio pid=243615 prio=120 target_cpu=031 ffffffff8bad311d ttwu_do_wakeup ([kernel.kallsyms])

--- a/src/LinuxTracing.Tests/Sources/one_wakeup.perf.data.dump
+++ b/src/LinuxTracing.Tests/Sources/one_wakeup.perf.data.dump
@@ -1,1 +1,2 @@
 ﻿         swapper     0/0     [009] 0.0:          1                sched:sched_wakeup: comm=fio pid=243615 prio=120 target_cpu=031 ffffffff8bad311d ttwu_do_wakeup ([kernel.kallsyms])
+         swapper     0/0     [009] 0.0:          1                sched:sched_wakeup: task fio:243615 [120] success=1 [031] ffffffff8bad311d ttwu_do_wakeup ([kernel.kallsyms])

--- a/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
+++ b/src/TraceEvent/Stacks/Linux/LinuxPerfScriptEventParser.cs
@@ -459,6 +459,12 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
                         IEnumerable<Frame> frames = ReadFramesForSample(processCommand, pid, tid, threadTimeFrame, source);
                         linuxEvent = new BlockReqCompleteEvent(processCommand, tid, pid, time, timeProp, cpu, eventName, eventDetails, frames, blockReqComplete);
                     }
+                    else if (eventDetails.Length > SchedWakeupEvent.Name.Length && eventDetails.Substring(0, SchedWakeupEvent.Name.Length) == SchedWakeupEvent.Name)
+                    {
+                        SchedWakeup schedWakeup = ReadSchedWakeup(source);
+                        IEnumerable<Frame> frames = ReadFramesForSample(processCommand, pid, tid, threadTimeFrame, source);
+                        linuxEvent = new SchedWakeupEvent(processCommand, tid, pid, time, timeProp, cpu, eventName, eventDetails, frames, schedWakeup);
+                    }
                     else
                     {
                         source.ReadAsciiStringUpTo('\n', sb);
@@ -966,6 +972,39 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             return new BlockReqComplete(device, deviceMinor, flags, sector, sectorLength, error);
         }
 
+        private SchedWakeup ReadSchedWakeup(FastStream source)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            // Format is: sched:sched_wakeup: comm=%s pid=%d prio=%d target_cpu=%03d
+
+            // Skip "sched:sched_wakeup: "
+            source.SkipUpTo(' ');
+            source.SkipSpace();
+
+            source.SkipUpTo('=');
+            source.MoveNext();
+            source.ReadAsciiStringUpTo(' ', sb);
+            string comm = sb.ToString();
+
+            source.SkipSpace();
+            source.SkipUpTo('=');
+            int pid = source.ReadInt();
+
+            source.SkipSpace();
+            source.SkipUpTo('=');
+            int priority = source.ReadInt();
+
+            source.SkipSpace();
+            source.SkipUpTo('=');
+            int targetCpu = source.ReadInt();
+
+            source.ReadAsciiStringUpTo('\n', sb);
+            sb.Clear();
+
+            return new SchedWakeup(comm, pid, priority, targetCpu);
+        }
+
         private void ReadProcessNameFromSchedSwitch(FastStream source, string nextFieldName, StringBuilder dest)
         {
             StringBuilder fieldNameStringBuilder = new StringBuilder();
@@ -1301,6 +1340,11 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
         /// Represents an IO complete event.
         /// </summary>
         BlockRequestComplete,
+
+        /// <summary>
+        /// Represents a wakeup event.
+        /// </summary>
+        Wakeup,
     }
 
     /// <summary>
@@ -1481,6 +1525,45 @@ namespace Microsoft.Diagnostics.Tracing.StackSources
             Sector = sector;
             SectorLength = sectorLength;
             Error = error;
+        }
+    }
+
+    /// <summary>
+    /// A sample that has extra properties to hold scheduler wakeup events.
+    /// </summary>
+    public class SchedWakeupEvent : LinuxEvent
+    {
+        public static readonly string Name = "sched_wakeup";
+
+        /// <summary>
+        /// The details of the wakeup.
+        /// </summary>
+        public SchedWakeup Wakeup { get; }
+
+        public SchedWakeupEvent(
+            string comm, int tid, int pid,
+            double time, int timeProp, int cpu,
+            string eventName, string eventProp, IEnumerable<Frame> callerStacks, SchedWakeup wakeup) :
+            base(EventKind.Wakeup, comm, tid, pid, time, timeProp, cpu, eventName, eventProp, callerStacks)
+        {
+            Wakeup = wakeup;
+        }
+    }
+
+    public class SchedWakeup
+    {
+        public string Comm { get; }
+        public int ProcessId { get; }
+        public int Priority { get; }
+        public int TargetCpu { get; }
+
+        public SchedWakeup(
+            string comm, int processId, int priority, int targetCpu)
+        {
+            Comm = comm;
+            ProcessId = processId;
+            Priority = priority;
+            TargetCpu = targetCpu;
         }
     }
 


### PR DESCRIPTION
Add support for the sched:sched_wakeup event.  This shows who is readying a thread for execution.